### PR TITLE
Change Platform::None to Platform::NONE to allow portability with other Coding Languages

### DIFF
--- a/include/ast.hpp
+++ b/include/ast.hpp
@@ -10,7 +10,7 @@
 namespace broma {
 	/// @brief The platform currently being processed in a bind statement.
 	enum class Platform {
-		None = 0,
+		NONE = 0,
 		Mac = 1,
 		Windows = 2,
 		Android = 4,

--- a/src/attribute.hpp
+++ b/src/attribute.hpp
@@ -105,7 +105,7 @@ namespace broma {
 	struct run_action<rule_begin<link_attribute>> {
 		template <typename T>
 		static void apply(T& input, Root* root, ScratchData* scratch) {
-			scratch->wip_attributes.links = Platform::None;
+			scratch->wip_attributes.links = Platform::NONE;
 		}
 	};
 
@@ -123,7 +123,7 @@ namespace broma {
 	struct run_action<rule_begin<missing_attribute>> {
 		template <typename T>
 		static void apply(T& input, Root* root, ScratchData* scratch) {
-			scratch->wip_attributes.missing = Platform::None;
+			scratch->wip_attributes.missing = Platform::NONE;
 		}
 	};
 	template <>


### PR DESCRIPTION
This has been somewhat of an Issue with my repository known as [PyBroma](https://github.com/CallocGD/PyBroma) because in Python the None Expression cannot be an assignment target and I was wondering if I could make these changes so that way my python port would be able to use the `Platform::None` enum with it. Hopefully this doesn't jack up or mess with the geode binding's code to any extreme degree and should be something rather simple and easy to migrate to as far as I am aware if this Pull Request is accepted. 

