### PR TITLE
Add a safe version of parsing broma files so that the code doesn't have to exit

### DIFF
--- a/include/ast.hpp
+++ b/include/ast.hpp
@@ -218,4 +218,20 @@ namespace broma {
 			return &*it;
 		}
 	};
+
+	/// @brief Used as a safety mechanism for parsing 
+	// broma files in other languages such as Rust and 
+	// Python or upon use with servers or when in use 
+	// with discord bots so that the code doesn't need 
+	// to exit upon having an error thrown.
+	typedef struct SafeRootResult {
+		/// @brief Root result if code has been parsed successfully.
+		Root root;
+		/// @brief A list of errors grabbed if any exist.
+		std::vector<char*>erros;
+		/// @brief a fag for check if parsing threw an error to begin with.
+		bool has_errors;
+	} SafeRootResult;
+
+
 } // namespace broma

--- a/include/ast.hpp
+++ b/include/ast.hpp
@@ -220,7 +220,7 @@ namespace broma {
 	};
 
 	/// @brief Used as a safety mechanism for parsing 
-	// in other languages or on multiple threads. 
+	// in other languages or on multiple threads.
 	typedef struct SafeRootResult {
 		void* result;
 		bool is_error;

--- a/include/ast.hpp
+++ b/include/ast.hpp
@@ -220,17 +220,10 @@ namespace broma {
 	};
 
 	/// @brief Used as a safety mechanism for parsing 
-	// broma files in other languages such as Rust and 
-	// Python or upon use with servers or when in use 
-	// with discord bots so that the code doesn't need 
-	// to exit upon having an error thrown.
+	// in other languages or on multiple threads. 
 	typedef struct SafeRootResult {
-		/// @brief Root result if code has been parsed successfully.
-		Root root;
-		/// @brief A list of errors grabbed if any exist.
-		std::vector<char*>erros;
-		/// @brief a fag for check if parsing threw an error to begin with.
-		bool has_errors;
+		void* result;
+		bool is_error;
 	} SafeRootResult;
 
 

--- a/include/broma.hpp
+++ b/include/broma.hpp
@@ -9,4 +9,10 @@ namespace broma {
 	///
 	/// @param fname The path of the file you want to parse, as a string.
 	Root parse_file(std::string const& fname);
+
+	/// @brief Parses a broma file safely by not exiting when the parser throws an error
+	/// @param fname The path of the file you want to parse, as a string.
+	/// @return A root result with a boolean value to check for errors.
+	SafeRootResult parse_file_safely(std::string const& fname);
+
 }

--- a/include/broma.hpp
+++ b/include/broma.hpp
@@ -11,7 +11,7 @@ namespace broma {
 	Root parse_file(std::string const& fname);
 
 	/// @brief Parses a broma file safely by not exiting when the parser throws an error
-	/// @param fname The path of the file you want to parse, as a string.
+	/// @param fname The path of the file you want to parse as a string.
 	/// @return A root result with a boolean value to check for errors.
 	SafeRootResult parse_file_safely(std::string const& fname);
 

--- a/include/broma.hpp
+++ b/include/broma.hpp
@@ -11,7 +11,7 @@ namespace broma {
 	Root parse_file(std::string const& fname);
 
 	/// @brief Parses a broma file safely by not exiting when the parser throws an error
-	/// @param fname The path of the file you want to parse as a string.
+	/// @param fname The filename or path of the file you want to parse as a string.
 	/// @return A root result with a boolean value to check for errors.
 	SafeRootResult parse_file_safely(std::string const& fname);
 

--- a/src/broma.cpp
+++ b/src/broma.cpp
@@ -36,4 +36,26 @@ namespace broma {
 
 		return root;
 	}
+
+	SafeRootResult parse_file_safely(std::string const& fname){
+		file_input<> input(fname);
+		
+		SafeRootResult srr;
+		
+		srr.has_errors = false;
+
+		ScratchData scratch;
+		parse<must<root_grammar>, run_action>(input, &srr.root, &scratch);
+		post_process(srr.root);
+		
+
+		if (scratch.errors.size()){
+			srr.has_errors = true;
+			
+			for (auto& e : scratch.errors) {
+				srr.erros.emplace_back(e.what());
+			}
+		}
+		return srr;
+	}
 } // namespace broma

--- a/src/broma.cpp
+++ b/src/broma.cpp
@@ -40,22 +40,24 @@ namespace broma {
 	SafeRootResult parse_file_safely(std::string const& fname){
 		file_input<> input(fname);
 		
-		SafeRootResult srr;
-		
-		srr.has_errors = false;
+		SafeRootResult result;
 
+		Root root;
 		ScratchData scratch;
-		parse<must<root_grammar>, run_action>(input, &srr.root, &scratch);
-		post_process(srr.root);
-		
+		parse<must<root_grammar>, run_action>(input, &root, &scratch);
+		post_process(root);
 
-		if (scratch.errors.size()){
-			srr.has_errors = true;
-			
-			for (auto& e : scratch.errors) {
-				srr.erros.emplace_back(e.what());
+		if (scratch.errors.size()) {
+			std::vector<char*>err_data;
+			for (auto&e : scratch.errors){
+				err_data.emplace_back(e.what());
 			}
+			result.result = reinterpret_cast<void*>(&err_data);
+			result.is_error = true;
+		} else {
+			result.result = reinterpret_cast<void*>(&root);
+			result.is_error = false;
 		}
-		return srr;
+		return result;
 	}
 } // namespace broma


### PR DESCRIPTION
This is a problem with pybroma where the script will exit when it shouldn't when handling lets just say multiple at a time and I am planning to make a discord bot that can summarize the geode bindings and other important elements and with a rust port on the way getting this in here felt like a must for me as the `std::exit(1)` part of this code infuriates me greatly as it's just not proper error handling if that makes any sense to anybody. I feel like error handling should be customized rather than simply exiting. when something is wrong, This was my attempt at writing a solution I had another idea to use a something similar to a `std::pair` for handling the result if required incase this pull request gets rejected.