### PR TITLE
Add nodefine attribute

### DIFF
--- a/include/ast.hpp
+++ b/include/ast.hpp
@@ -76,6 +76,7 @@ namespace broma {
 		std::string docs; ///< Any docstring pulled from a `[[docs(...)]]` attribute.
 		Platform links = Platform::None; ///< All the platforms that link the class or function
 		Platform missing = Platform::None; ///< All the platforms that are missing the class or function
+		Platform nodefine = Platform::None; ///< All the platforms that should not define the class or function
 		std::vector<std::string> depends; ///< List of classes that this class or function depends on
 	};
 

--- a/src/attribute.hpp
+++ b/src/attribute.hpp
@@ -53,6 +53,13 @@ namespace broma {
 		>
 	>> {};
 
+	struct nodefine_attribute : basic_attribute<TAO_PEGTL_KEYWORD("nodefine"), tagged_rule<nodefine_attribute,
+		seq<
+			rule_begin<nodefine_attribute>,
+			opt<platform_list<nodefine_attribute>>
+		>
+	>> {};
+
 	/// @brief All allowed C++ attributes.
 	///
 	/// Currently, this includes the `docs(...)`, `depends(...)`, `link(...)` and `missing(...)` attributes.
@@ -64,7 +71,7 @@ namespace broma {
 				success,
 				list<seq<
 					sep,
-					sor<depends_attribute, link_attribute, missing_attribute>,
+					sor<depends_attribute, link_attribute, missing_attribute, nodefine_attribute>,
 					sep
 				>, one<','>>
 			>,
@@ -131,6 +138,24 @@ namespace broma {
 		template <typename T>
 		static void apply(T& input, Root* root, ScratchData* scratch) {
 			scratch->wip_attributes.missing |= str_to_platform(input.string());
+		}
+	};
+
+	// nodefine
+
+	template <>
+	struct run_action<rule_begin<nodefine_attribute>> {
+		template <typename T>
+		static void apply(T& input, Root* root, ScratchData* scratch) {
+			scratch->wip_attributes.nodefine = Platform::None;
+		}
+	};
+
+	template <>
+	struct run_action<tagged_platform<nodefine_attribute>> {
+		template <typename T>
+		static void apply(T& input, Root* root, ScratchData* scratch) {
+			scratch->wip_attributes.nodefine |= str_to_platform(input.string());
 		}
 	};
 

--- a/src/function.hpp
+++ b/src/function.hpp
@@ -99,6 +99,7 @@ namespace broma {
 			scratch->wip_attributes = Attributes();
 			scratch->wip_attributes.links = scratch->wip_class.attributes.links;
 			scratch->wip_attributes.missing = scratch->wip_class.attributes.missing;
+			scratch->wip_attributes.nodefine = scratch->wip_class.attributes.nodefine;
 
 			scratch->wip_mem_fn_proto = MemberFunctionProto();
 		}


### PR DESCRIPTION
For functions that have bindings but are somehow reimplemented in a different way (_cough cough_ CCArray)